### PR TITLE
feat: adds default gzip and brotli compression, variables to allow disabling

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -30,9 +30,11 @@ locals {
     }, var.cloudfront.hsts)
     waf_logging_configuration = var.cloudfront.waf_logging_configuration
     cache_policy = {
-      default_ttl = coalesce(try(var.cloudfront.cache_policy.default_ttl, null), 0)
-      min_ttl     = coalesce(try(var.cloudfront.cache_policy.min_ttl, null), 0)
-      max_ttl     = coalesce(try(var.cloudfront.cache_policy.max_ttl, null), 31536000)
+      default_ttl                   = coalesce(try(var.cloudfront.cache_policy.default_ttl, null), 0)
+      min_ttl                       = coalesce(try(var.cloudfront.cache_policy.min_ttl, null), 0)
+      max_ttl                       = coalesce(try(var.cloudfront.cache_policy.max_ttl, null), 31536000)
+      enable_accept_encoding_brotli = try(var.cloudfront.cache_policy.enable_accept_encoding_brotli, true)
+      enable_accept_encoding_gzip   = try(var.cloudfront.cache_policy.enable_accept_encoding_gzip, true)
       cookies_config = merge({
         cookie_behavior = "all"
       }, try(var.cloudfront.cache_policy.cookies_config, {}))

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -60,8 +60,10 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
   min_ttl     = var.cache_policy.min_ttl
   max_ttl     = var.cache_policy.max_ttl
 
-
   parameters_in_cache_key_and_forwarded_to_origin {
+    enable_accept_encoding_brotli = var.cache_policy.enable_accept_encoding_brotli
+    enable_accept_encoding_gzip   = var.cache_policy.enable_accept_encoding_gzip
+
     cookies_config {
       cookie_behavior = var.cache_policy.cookies_config.cookie_behavior
 

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -135,9 +135,11 @@ variable "origin_request_policy" {
 
 variable "cache_policy" {
   type = object({
-    default_ttl = number
-    min_ttl     = number
-    max_ttl     = number
+    default_ttl                   = number
+    min_ttl                       = number
+    max_ttl                       = number
+    enable_accept_encoding_gzip   = bool
+    enable_accept_encoding_brotli = bool
     cookies_config = object({
       cookie_behavior = string
       items           = optional(list(string))

--- a/variables.tf
+++ b/variables.tf
@@ -358,9 +358,11 @@ variable "cloudfront" {
       })))
     }))
     cache_policy = optional(object({
-      default_ttl = optional(number)
-      min_ttl     = optional(number)
-      max_ttl     = optional(number)
+      default_ttl                   = optional(number)
+      min_ttl                       = optional(number)
+      max_ttl                       = optional(number)
+      enable_accept_encoding_gzip   = optional(bool)
+      enable_accept_encoding_brotli = optional(bool)
       cookies_config = optional(object({
         cookie_behavior = string
       }))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Gzip and Brotli compressions are currently disabled by the Cloudfront Cache Policy resulting in Next.js not Gzipping content as the headers do not get passed to origin. 

This PR enables these options by default, and sets variables to disable if needed.

<!-- Describe your changes in detail. -->

## Context

This PR results in lower network data transfer by enabling Gzip and Brotli across the Cloudfront Cache Policy 

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
