### PR TITLE
Feature/custom waf arn

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -28,6 +28,7 @@ locals {
       override                   = true
       preload                    = true
     }, var.cloudfront.hsts)
+    custom_waf_acl_arn        = try(var.cloudfront.custom_waf_acl_arn, null)
     waf_logging_configuration = var.cloudfront.waf_logging_configuration
     cache_policy = {
       default_ttl                   = coalesce(try(var.cloudfront.cache_policy.default_ttl, null), 0)

--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,7 @@ module "cloudfront" {
   geo_restriction           = local.cloudfront.geo_restriction
   cors                      = local.cloudfront.cors
   hsts                      = local.cloudfront.hsts
+  custom_waf_acl_arn        = local.cloudfront.custom_waf_acl_arn
   waf_logging_configuration = local.cloudfront.waf_logging_configuration
   cache_policy              = local.cloudfront.cache_policy
 }

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -155,7 +155,7 @@ resource "aws_cloudfront_distribution" "distribution" {
   is_ipv6_enabled = true
   comment         = "${var.prefix} - CloudFront Distribution for Next.js Application"
   aliases         = var.aliases
-  web_acl_id      = aws_wafv2_web_acl.cloudfront_waf.arn
+  web_acl_id      = try(var.custom_waf_acl_arn, aws_wafv2_web_acl.cloudfront_waf[1].arn)
 
   logging_config {
     include_cookies = false

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -85,6 +85,11 @@ variable "hsts" {
   }
 }
 
+variable "custom_waf_acl_arn" {
+  description = "ARN value for an externally created AWS WAF"
+  type        = string
+}
+
 variable "waf_logging_configuration" {
   description = "Logging Configuration for the WAF attached to CloudFront"
   type = object({

--- a/modules/opennext-cloudfront/waf.tf
+++ b/modules/opennext-cloudfront/waf.tf
@@ -1,4 +1,5 @@
 resource "aws_wafv2_web_acl" "cloudfront_waf" {
+  count    = var.custom_waf_acl_arn == null ? 1 : 0
   provider = aws.global
   name     = "${var.prefix}-waf"
   scope    = "CLOUDFRONT"
@@ -122,7 +123,7 @@ resource "aws_wafv2_web_acl" "cloudfront_waf" {
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
   count = var.waf_logging_configuration == null ? 0 : 1
 
-  resource_arn            = aws_wafv2_web_acl.cloudfront_waf.arn
+  resource_arn            = aws_wafv2_web_acl.cloudfront_waf[1].arn
   log_destination_configs = var.waf_logging_configuration.log_destination_configs
 
   dynamic "logging_filter" {

--- a/variables.tf
+++ b/variables.tf
@@ -333,6 +333,7 @@ variable "cloudfront" {
       override                   = bool
       preload                    = bool
     }))
+    custom_waf_acl_arn = optional(string)
     waf_logging_configuration = optional(object({
       log_destination_configs = list(string)
       logging_filter = optional(object({


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Some organisations might want to configure a WAF externally to this module, and pass in the ARN from the WAF ACL, this PR allows the ability for a `custom_waf_acl_arn` to be passed to this module, when it is passed and not null, it will not create the WAF resource, and will assign the `custom_waf_acl_arn` to Cloudfront instead of the created resource.

If the passed `custom_waf_acl_arn` variable is null, it will still create the WAF resource for security best practices.

<!-- Describe your changes in detail. -->

## Context

Specifc to the way we do things at Gymshark, we have a set of WAF rules we have setup for our web applications, configuring and maintaining our own WAF is more beneficial than a generic WAF setup. We need the ability to pass this already created WAF ARN to this new Next.js Cloudfront distro so we can maintain our own security requirements.   

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
