### PR TITLE
Fix initial deploy invalid count dependency error

### DIFF
--- a/modules/opennext-cloudfront/waf.tf
+++ b/modules/opennext-cloudfront/waf.tf
@@ -122,7 +122,7 @@ resource "aws_wafv2_web_acl" "cloudfront_waf" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
-  count = var.waf_logging_configuration == null || try(aws_wafv2_web_acl.cloudfront_waf[0], null) == null ? 0 : 1
+  count = var.waf_logging_configuration == null || var.custom_waf != null ? 0 : 1
 
   resource_arn            = aws_wafv2_web_acl.cloudfront_waf[0].arn
   log_destination_configs = var.waf_logging_configuration.log_destination_configs

--- a/modules/opennext-cloudfront/waf.tf
+++ b/modules/opennext-cloudfront/waf.tf
@@ -122,7 +122,7 @@ resource "aws_wafv2_web_acl" "cloudfront_waf" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
-  count = var.waf_logging_configuration == null || var.custom_waf == null ? 0 : 1
+  count = var.waf_logging_configuration == null || var.custom_waf != null ? 0 : 1
 
   resource_arn            = aws_wafv2_web_acl.cloudfront_waf[0].arn
   log_destination_configs = var.waf_logging_configuration.log_destination_configs

--- a/modules/opennext-cloudfront/waf.tf
+++ b/modules/opennext-cloudfront/waf.tf
@@ -122,7 +122,7 @@ resource "aws_wafv2_web_acl" "cloudfront_waf" {
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
-  count = var.waf_logging_configuration == null || var.custom_waf != null ? 0 : 1
+  count = var.waf_logging_configuration == null || var.custom_waf == null ? 0 : 1
 
   resource_arn            = aws_wafv2_web_acl.cloudfront_waf[0].arn
   log_destination_configs = var.waf_logging_configuration.log_destination_configs


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

Fixing #16 - which happens due to the code below

```terraform
# modules/opennext-cloudfront/waf.tf
resource "aws_wafv2_web_acl" "cloudfront_waf" {
  count = var.custom_waf == null ? 1 : 0
  ...
}

resouce "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
  count = var.waf_logging_configuration == null || try(aws_wafv2_web_acl.cloudfront_waf[0], null) == null ? 0 : 1
  ...
}
```

If you reference another resource in the `count` argument, terraform will fail on initial deploy because that other resource won't exist yet, so the count argument is not yet defined, but terraform needs the count argument to be defined for a deploy.

All the code is trying to do is deploy `aws_wafv2_web_acl_logging_configuration.waf_logging` only if the `aws_wafv2_web_acl.cloudfront_waf` exists (has count > 0). We can do this without causing this terraform error by simply placing the condition in the count for `aws_wafv2_web_acl.cloudfront_waf` inside of `aws_wafv2_web_acl_logging_configuration.waf_logging`'s count condition.

Like this:

```terraform
resource "aws_wafv2_web_acl_logging_configuration" "waf_logging" {
  count = var.waf_logging_configuration == null || var.custom_waf != null ? 0 : 1
  
  ...
}
```


## Context

<!-- Why is this change required? What problem does it solve? -->

Issue #16 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
