### PR TITLE
Server lambda errors

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -104,7 +104,7 @@ locals {
     iam_policy_statements = concat([
       {
         effect    = "Allow"
-        actions   = ["s3:GetObject", "s3:PutObject", "s3:ListObjects"]
+        actions   = ["s3:GetObject", "s3:PutObject", "s3:ListObjects", "s3:DeleteObjects"]
         resources = [module.assets.assets_bucket.arn, "${module.assets.assets_bucket.arn}/*"]
       },
       {

--- a/main.tf
+++ b/main.tf
@@ -31,6 +31,40 @@ module "assets" {
   static_asset_cache_config = var.static_asset_cache_config
 }
 
+resource "aws_dynamodb_table" "tag_cache" {
+  count        = var.use_tagcache == true ? 1 : 0
+  name         = "${var.prefix}-tagcache"
+  hash_key     = "path"
+  range_key    = "tag"
+  billing_mode = "PAY_PER_REQUEST"
+
+  attribute {
+    name = "path"
+    type = "S"
+  }
+  attribute {
+    name = "tag"
+    type = "S"
+  }
+  attribute {
+    name = "revalidatedAt"
+    type = "N"
+  }
+  server_side_encryption {
+    enabled = true
+  }
+
+  global_secondary_index {
+    hash_key           = "path"
+    name               = "revalidate"
+    non_key_attributes = []
+    projection_type    = "ALL"
+    range_key          = "revalidatedAt"
+    read_capacity      = 0
+    write_capacity     = 0
+  }
+}
+
 
 /**
  * Next.js Server Function

--- a/variables.tf
+++ b/variables.tf
@@ -418,3 +418,8 @@ variable "cloudfront" {
     }))
   })
 }
+
+variable "use_tagcache" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added a variable (use_tagcache) to enable or not the creation of a dynamoDB table so OpenNext can use its TagCache features.
Also added the DeleteObject permission to the server lambda.
## Context

I have been using this module for a while now, when you look into the server lambda logs two errors can be found:
- s3 access denied (DeleteObject)
- DynamoDB undefined table name

The code is made to be backwards compatible.

## Type of changes

Added permission to the server lambda.

Added variable (bool) to enable or nor the TagCache feature.

Added a conditional dynamodb table.

Added a conditional permission on the server lambda.

Added a conditional environment variable to the server lambda.

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
