### PR TITLE
Add new security headers to cloudfront

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -53,7 +53,9 @@ locals {
       }, try(var.cloudfront.cache_policy.query_strings_config, {}))
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
-    existing_cache_policy = try(var.cloudfront.existing_cache_policy, null)
+    
+    existing_cache_policy            = try(var.cloudfront.existing_cache_policy, null)
+    existing_response_headers_policy = try(var.cloudfront.existing_response_headers_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/locals.tf
+++ b/locals.tf
@@ -53,6 +53,7 @@ locals {
       }, try(var.cloudfront.cache_policy.query_strings_config, {}))
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
+    existing_cache_policy = try(var.cloudfront.existing_cache_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/locals.tf
+++ b/locals.tf
@@ -54,8 +54,8 @@ locals {
     }
     origin_request_policy = try(var.cloudfront.origin_request_policy, null)
     
-    existing_cache_policy            = try(var.cloudfront.existing_cache_policy, null)
-    existing_response_headers_policy = try(var.cloudfront.existing_response_headers_policy, null)
+    custom_cache_policy            = try(var.cloudfront.custom_cache_policy, null)
+    custom_response_headers_policy = try(var.cloudfront.custom_response_headers_policy, null)
 
     custom_waf                = var.cloudfront.custom_waf
     waf_logging_configuration = var.cloudfront.waf_logging_configuration

--- a/locals.tf
+++ b/locals.tf
@@ -272,4 +272,11 @@ locals {
       }
     ], coalesce(try(var.warmer_options.iam_policy, null), []))
   }
+
+  /**
+   * CloudFront Log Options
+   **/
+  cloudfront_log_options = {
+    cloudwatch_log_group_kms_key_arn = try(var.cloudfront_log_options.cloudwatch_log_group_kms_key_arn, null)
+  }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -30,6 +30,21 @@ locals {
       override                   = true
       preload                    = true
     }, var.cloudfront.hsts)
+    content_security_policy = merge({
+      override = true
+      policy   = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+    }, var.cloudfront.content_security_policy)
+    content_type_options = merge({
+      override = true
+    }, var.cloudfront.content_type_options)
+    frame_options = merge({
+      override = true
+      option   = "DENY"
+    }, var.cloudfront.frame_options)
+    referrer_policy = merge({
+      override = true
+      policy   = "strict-origin-when-cross-origin"
+    }, var.cloudfront.referrer_policy)
     remove_headers_config = merge({
       items : []
     }, var.cloudfront.remove_headers_config)

--- a/locals.tf
+++ b/locals.tf
@@ -91,6 +91,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.server_options.networking.vpc_id, null)
+      subnet_map_public_ip         = try(var.server_options.networking.subnet_map_public_ip, null)
       subnet_ids                   = coalesce(try(var.server_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.server_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.server_options.networking.sg_egress_rules, null), [])
@@ -153,6 +154,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.image_optimization_options.networking.vpc_id, null)
+      subnet_map_public_ip         = try(var.image_optimization_options.networking.subnet_map_public_ip, null)
       subnet_ids                   = coalesce(try(var.image_optimization_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.image_optimization_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.image_optimization_options.networking.sg_egress_rules, null), [])
@@ -203,6 +205,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.revalidation_options.networking.vpc_id, null)
+      subnet_map_public_ip         = try(var.revalidation_options.networking.subnet_map_public_ip, null)
       subnet_ids                   = coalesce(try(var.revalidation_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.revalidation_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.revalidation_options.networking.sg_egress_rules, null), [])
@@ -261,6 +264,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.warmer_options.networking.vpc_id, null)
+      subnet_map_public_ip         = try(var.warmer_options.networking.subnet_map_public_ip, null)
       subnet_ids                   = coalesce(try(var.warmer_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.warmer_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.warmer_options.networking.sg_egress_rules, null), [])

--- a/locals.tf
+++ b/locals.tf
@@ -91,7 +91,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.server_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.server_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.server_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.server_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.server_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.server_options.networking.sg_egress_rules, null), [])
@@ -154,7 +154,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.image_optimization_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.image_optimization_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.image_optimization_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.image_optimization_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.image_optimization_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.image_optimization_options.networking.sg_egress_rules, null), [])
@@ -205,7 +205,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.revalidation_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.revalidation_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.revalidation_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.revalidation_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.revalidation_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.revalidation_options.networking.sg_egress_rules, null), [])
@@ -264,7 +264,7 @@ locals {
 
     networking = {
       vpc_id                       = try(var.warmer_options.networking.vpc_id, null)
-      subnet_map_public_ip         = try(var.warmer_options.networking.subnet_map_public_ip, null)
+      subnet_map_public_ip         = coalesce(try(var.warmer_options.networking.subnet_map_public_ip, null), false)
       subnet_ids                   = coalesce(try(var.warmer_options.networking.subnet_ids, null), [])
       security_group_ingress_rules = coalesce(try(var.warmer_options.networking.sg_ingress_rules, null), [])
       security_group_egress_rules  = coalesce(try(var.warmer_options.networking.sg_egress_rules, null), [])

--- a/locals.tf
+++ b/locals.tf
@@ -17,13 +17,13 @@ locals {
       locations        = []
     })
     price_class = coalesce(try(var.cloudfront.price_class, null), "PriceClass_All")
-    cors = merge({
-      allow_credentials = false,
-      allow_headers     = ["*"],
-      allow_methods     = ["ALL"],
-      allow_origins     = ["*"],
-      origin_override   = true
-    }, var.cloudfront.cors)
+    cors = {
+      allow_credentials = coalesce(var.cloudfront.cors.allow_credentials, false)
+      allow_headers     = coalesce(var.cloudfront.cors.allow_headers, ["*"])
+      allow_methods     = coalesce(var.cloudfront.cors.allow_methods, ["ALL"])
+      allow_origins     = coalesce(var.cloudfront.cors.allow_origins, ["*"])
+      origin_override   = coalesce(var.cloudfront.cors.origin_override, true)
+    }
     hsts = merge({
       access_control_max_age_sec = 31536000
       include_subdomains         = true

--- a/locals.tf
+++ b/locals.tf
@@ -225,6 +225,13 @@ locals {
   }
 
   /**
+   * ISR Revalidation Queue Options
+   **/
+  revalidation_queue_options = {
+    kms_key_arn = try(var.revalidation_queue_options.kms_key_arn, null)
+  }
+
+  /**
    * Warmer Function Options
    **/
   warmer_options = {

--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,8 @@ module "revalidation_queue" {
 
   aws_account_id            = data.aws_caller_identity.current.account_id
   revalidation_function_arn = module.revalidation_function.lambda_function.arn
+
+  kms_key_arn = local.revalidation_queue_options.kms_key_arn
 }
 
 /**

--- a/main.tf
+++ b/main.tf
@@ -240,15 +240,19 @@ module "cloudfront" {
     image_optimization_function = "${module.image_optimization_function.lambda_function_url.url_id}.lambda-url.${local.aws_region}.on.aws"
   }
 
-  aliases               = local.cloudfront.aliases
-  acm_certificate_arn   = local.cloudfront.acm_certificate_arn
-  assets_paths          = local.cloudfront.assets_paths
-  custom_headers        = local.cloudfront.custom_headers
-  geo_restriction       = local.cloudfront.geo_restriction
-  cors                  = local.cloudfront.cors
-  hsts                  = local.cloudfront.hsts
-  cache_policy          = local.cloudfront.cache_policy
-  remove_headers_config = local.cloudfront.remove_headers_config
+  aliases                 = local.cloudfront.aliases
+  acm_certificate_arn     = local.cloudfront.acm_certificate_arn
+  assets_paths            = local.cloudfront.assets_paths
+  custom_headers          = local.cloudfront.custom_headers
+  geo_restriction         = local.cloudfront.geo_restriction
+  cors                    = local.cloudfront.cors
+  hsts                    = local.cloudfront.hsts
+  content_security_policy = local.cloudfront.content_security_policy
+  content_type_options    = local.cloudfront.content_type_options
+  frame_options           = local.cloudfront.frame_options
+  referrer_policy         = local.cloudfront.referrer_policy
+  cache_policy            = local.cloudfront.cache_policy
+  remove_headers_config   = local.cloudfront.remove_headers_config
 
   custom_cache_policy            = local.cloudfront.custom_cache_policy
   custom_response_headers_policy = local.cloudfront.custom_response_headers_policy

--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ module "server_function" {
 
   vpc_id                       = local.server_options.networking.vpc_id
   subnet_ids                   = local.server_options.networking.subnet_ids
+  subnet_map_public_ip         = local.server_options.networking.subnet_map_public_ip
   security_group_ingress_rules = local.server_options.networking.security_group_ingress_rules
   security_group_egress_rules  = local.server_options.networking.security_group_egress_rules
 
@@ -97,6 +98,7 @@ module "image_optimization_function" {
 
   vpc_id                       = local.image_optimization_options.networking.vpc_id
   subnet_ids                   = local.image_optimization_options.networking.subnet_ids
+  subnet_map_public_ip         = local.image_optimization_options.networking.subnet_map_public_ip
   security_group_ingress_rules = local.image_optimization_options.networking.security_group_ingress_rules
   security_group_egress_rules  = local.image_optimization_options.networking.security_group_egress_rules
 
@@ -132,6 +134,7 @@ module "revalidation_function" {
 
   vpc_id                       = local.revalidation_options.networking.vpc_id
   subnet_ids                   = local.revalidation_options.networking.subnet_ids
+  subnet_map_public_ip         = local.revalidation_options.networking.subnet_map_public_ip
   security_group_ingress_rules = local.revalidation_options.networking.security_group_ingress_rules
   security_group_egress_rules  = local.revalidation_options.networking.security_group_egress_rules
 
@@ -185,6 +188,7 @@ module "warmer_function" {
 
   vpc_id                       = local.warmer_options.networking.vpc_id
   subnet_ids                   = local.warmer_options.networking.subnet_ids
+  subnet_map_public_ip         = local.warmer_options.networking.subnet_map_public_ip
   security_group_ingress_rules = local.warmer_options.networking.security_group_ingress_rules
   security_group_egress_rules  = local.warmer_options.networking.security_group_egress_rules
 

--- a/main.tf
+++ b/main.tf
@@ -201,6 +201,8 @@ module "cloudfront_logs" {
   log_group_name  = "${var.prefix}-cloudfront-logs"
   log_bucket_name = "${var.prefix}-cloudfront-logs"
   retention       = 365
+
+  cloudwatch_log_group_kms_key_arn = local.cloudfront_log_options.cloudwatch_log_group_kms_key_arn
 }
 
 /**

--- a/main.tf
+++ b/main.tf
@@ -233,7 +233,9 @@ module "cloudfront" {
   hsts                  = local.cloudfront.hsts
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
-  existing_cache_policy = local.cloudfront.existing_cache_policy
+
+  existing_cache_policy            = local.cloudfront.existing_cache_policy
+  existing_response_headers_policy = local.cloudfront.existing_response_headers_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/main.tf
+++ b/main.tf
@@ -234,8 +234,8 @@ module "cloudfront" {
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
 
-  existing_cache_policy            = local.cloudfront.existing_cache_policy
-  existing_response_headers_policy = local.cloudfront.existing_response_headers_policy
+  custom_cache_policy            = local.cloudfront.custom_cache_policy
+  custom_response_headers_policy = local.cloudfront.custom_response_headers_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [
+        aws.global,
+      ]
     }
   }
 }
@@ -216,6 +219,11 @@ module "cloudfront_logs" {
  **/
 module "cloudfront" {
   source       = "./modules/opennext-cloudfront"
+  providers = {
+    aws        = aws
+    aws.global = aws.global
+  }
+
   prefix       = "${var.prefix}-cloudfront"
   region       = local.aws_region
   default_tags = var.default_tags

--- a/main.tf
+++ b/main.tf
@@ -233,6 +233,7 @@ module "cloudfront" {
   hsts                  = local.cloudfront.hsts
   cache_policy          = local.cloudfront.cache_policy
   remove_headers_config = local.cloudfront.remove_headers_config
+  existing_cache_policy = local.cloudfront.existing_cache_policy
 
   custom_waf                = local.cloudfront.custom_waf
   waf_logging_configuration = local.cloudfront.waf_logging_configuration

--- a/modules/cloudfront-logs/main.tf
+++ b/modules/cloudfront-logs/main.tf
@@ -13,19 +13,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}
-
-provider "aws" {
-  alias  = "global"
-  region = "us-east-1"
-
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-assets/main.tf
+++ b/modules/opennext-assets/main.tf
@@ -8,10 +8,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -2,7 +2,9 @@ locals {
   server_origin_id             = "${var.prefix}-server-origin"
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
-  cloudfront_cache_policy_id   = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+
+  cloudfront_cache_policy_id            = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+  cloudfront_response_headers_policy_id = var.existing_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -109,7 +111,14 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
   }
 }
 
+data "aws_cloudfront_response_headers_policy" "response_headers_policy" {
+  count = var.existing_response_headers_policy == null ? 0 : 1
+  name  = var.existing_response_headers_policy.name
+  id    = var.existing_response_headers_policy.id
+}
+
 resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
+  count   = var.existing_response_headers_policy == null ? 1 : 0
   name    = "${var.prefix}-response-headers-policy"
   comment = "${var.prefix} Response Headers Policy"
 
@@ -244,7 +253,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.assets_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -261,7 +270,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.image_optimization_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -278,7 +287,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -300,7 +309,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -322,7 +331,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD"]
     target_origin_id = local.assets_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -342,7 +351,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       cached_methods   = ["GET", "HEAD", "OPTIONS"]
       target_origin_id = local.assets_origin_id
 
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+      response_headers_policy_id = local.cloudfront_response_headers_policy_id
       cache_policy_id            = local.cloudfront_cache_policy_id
       origin_request_policy_id = try(
         data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
@@ -359,7 +368,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = local.server_origin_id
 
-    response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    response_headers_policy_id = local.cloudfront_response_headers_policy_id
     cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -3,8 +3,8 @@ locals {
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
 
-  cloudfront_cache_policy_id            = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
-  cloudfront_response_headers_policy_id = var.existing_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
+  cloudfront_cache_policy_id            = var.custom_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
+  cloudfront_response_headers_policy_id = var.custom_response_headers_policy == null ? aws_cloudfront_response_headers_policy.response_headers_policy[0].id : data.aws_cloudfront_response_headers_policy.response_headers_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -57,13 +57,13 @@ resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
 }
 
 data "aws_cloudfront_cache_policy" "cache_policy" {
-  count = var.existing_cache_policy == null ? 0 : 1
-  name  = var.existing_cache_policy.name
-  id    = var.existing_cache_policy.id
+  count = var.custom_cache_policy == null ? 0 : 1
+  name  = var.custom_cache_policy.name
+  id    = var.custom_cache_policy.id
 }
 
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-  count = var.existing_cache_policy == null ? 1 : 0
+  count = var.custom_cache_policy == null ? 1 : 0
   name  = "${var.prefix}-cache-policy"
 
   default_ttl = var.cache_policy.default_ttl
@@ -112,13 +112,13 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
 }
 
 data "aws_cloudfront_response_headers_policy" "response_headers_policy" {
-  count = var.existing_response_headers_policy == null ? 0 : 1
-  name  = var.existing_response_headers_policy.name
-  id    = var.existing_response_headers_policy.id
+  count = var.custom_response_headers_policy == null ? 0 : 1
+  name  = var.custom_response_headers_policy.name
+  id    = var.custom_response_headers_policy.id
 }
 
 resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
-  count   = var.existing_response_headers_policy == null ? 1 : 0
+  count   = var.custom_response_headers_policy == null ? 1 : 0
   name    = "${var.prefix}-response-headers-policy"
   comment = "${var.prefix} Response Headers Policy"
 

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -2,6 +2,7 @@ locals {
   server_origin_id             = "${var.prefix}-server-origin"
   assets_origin_id             = "${var.prefix}-assets-origin"
   image_optimization_origin_id = "${var.prefix}-image-optimization-origin"
+  cloudfront_cache_policy_id   = var.existing_cache_policy == null ? aws_cloudfront_cache_policy.cache_policy[0].id : data.aws_cloudfront_cache_policy.cache_policy[0].id
 }
 
 resource "aws_cloudfront_function" "host_header_function" {
@@ -53,8 +54,15 @@ resource "aws_cloudfront_origin_request_policy" "origin_request_policy" {
   }
 }
 
+data "aws_cloudfront_cache_policy" "cache_policy" {
+  count = var.existing_cache_policy == null ? 0 : 1
+  name  = var.existing_cache_policy.name
+  id    = var.existing_cache_policy.id
+}
+
 resource "aws_cloudfront_cache_policy" "cache_policy" {
-  name = "${var.prefix}-cache-policy"
+  count = var.existing_cache_policy == null ? 1 : 0
+  name  = "${var.prefix}-cache-policy"
 
   default_ttl = var.cache_policy.default_ttl
   min_ttl     = var.cache_policy.min_ttl
@@ -237,7 +245,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.assets_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -254,7 +262,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.image_optimization_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -271,7 +279,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -293,7 +301,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -315,7 +323,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.assets_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -335,7 +343,7 @@ resource "aws_cloudfront_distribution" "distribution" {
       target_origin_id = local.assets_origin_id
 
       response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+      cache_policy_id            = local.cloudfront_cache_policy_id
       origin_request_policy_id = try(
         data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
         aws_cloudfront_origin_request_policy.origin_request_policy[0].id
@@ -352,7 +360,7 @@ resource "aws_cloudfront_distribution" "distribution" {
     target_origin_id = local.server_origin_id
 
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
+    cache_policy_id            = local.cloudfront_cache_policy_id
     origin_request_policy_id = try(
       data.aws_cloudfront_origin_request_policy.origin_request_policy[0].id,
       aws_cloudfront_origin_request_policy.origin_request_policy[0].id

--- a/modules/opennext-cloudfront/cloudfront.tf
+++ b/modules/opennext-cloudfront/cloudfront.tf
@@ -140,6 +140,25 @@ resource "aws_cloudfront_response_headers_policy" "response_headers_policy" {
   }
 
   security_headers_config {
+    content_security_policy {
+      override                = var.content_security_policy.override
+      content_security_policy = var.content_security_policy.policy
+    }
+
+    content_type_options {
+      override = var.content_type_options.override
+    }
+
+    frame_options {
+      override     = var.frame_options.override
+      frame_option = var.frame_options.option
+    }
+
+    referrer_policy {
+      override        = var.referrer_policy.override
+      referrer_policy = var.referrer_policy.policy
+    }
+
     strict_transport_security {
       access_control_max_age_sec = var.hsts.access_control_max_age_sec
       include_subdomains         = var.hsts.include_subdomains

--- a/modules/opennext-cloudfront/main.tf
+++ b/modules/opennext-cloudfront/main.tf
@@ -5,22 +5,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+      configuration_aliases = [
+        aws.global,
+      ]
     }
-  }
-}
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}
-
-provider "aws" {
-  alias  = "global"
-  region = "us-east-1"
-
-  default_tags {
-    tags = var.default_tags
   }
 }

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -104,6 +104,52 @@ variable "hsts" {
   }
 }
 
+variable "content_security_policy" {
+  description = "Content-Security-Policy security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    policy   = string
+  })
+  default = {
+    override = true
+    policy   = "default-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:"
+  }
+}
+
+variable "content_type_options" {
+  description = "X-Content-Type-Options security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+  })
+  default = {
+    override = true
+  }
+}
+
+variable "frame_options" {
+  description = "X-Frame-Options security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    option   = string
+  })
+  default = {
+    override = true
+    option   = "DENY"
+  }
+}
+
+variable "referrer_policy" {
+  description = "Referrer-Policy security header configuration for the CloudFront distribution"
+  type = object({
+    override = bool
+    policy   = string
+  })
+  default = {
+    override = true
+    policy   = "strict-origin-when-cross-origin"
+  }
+}
+
 variable "custom_waf" {
   description = "ARN value for an externally created AWS WAF"
   type = object({

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -203,3 +203,11 @@ variable "existing_cache_policy" {
     id   = optional(string)
   })
 }
+
+variable "existing_response_headers_policy" {
+  description = "Details for data calling existing CloudFront response headers policy"
+  type = object({
+    name = optional(string)
+    id   = optional(string)
+  })
+}

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -196,3 +196,10 @@ variable "remove_headers_config" {
   })
 }
 
+variable "existing_cache_policy" {
+  description = "Details for data calling existing CloudFront cache policy"
+  type = object({
+    name = optional(string)
+    id   = optional(string)
+  })
+}

--- a/modules/opennext-cloudfront/variables.tf
+++ b/modules/opennext-cloudfront/variables.tf
@@ -196,7 +196,7 @@ variable "remove_headers_config" {
   })
 }
 
-variable "existing_cache_policy" {
+variable "custom_cache_policy" {
   description = "Details for data calling existing CloudFront cache policy"
   type = object({
     name = optional(string)
@@ -204,7 +204,7 @@ variable "existing_cache_policy" {
   })
 }
 
-variable "existing_response_headers_policy" {
+variable "custom_response_headers_policy" {
   description = "Details for data calling existing CloudFront response headers policy"
   type = object({
     name = optional(string)

--- a/modules/opennext-lambda/data.tf
+++ b/modules/opennext-lambda/data.tf
@@ -4,3 +4,27 @@ data "archive_file" "lambda_zip" {
   source_dir  = var.source_dir
   output_path = "${var.output_dir}${var.prefix}.zip"
 }
+
+data "aws_vpc" "this" {
+  count = var.vpc_id == null ? 0 : 1
+  id    = var.vpc_id
+}
+
+data "aws_subnets" "this" {
+  count = var.vpc_id == null ? 0 : 1
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.this[0].id]
+  }
+  filter {
+    name   = "map-public-ip-on-launch"
+    values = [var.subnet_map_public_ip]
+  }
+  dynamic "filter" {
+    for_each = length(var.subnet_ids) > 0 ? [1] : []
+    content {
+      name   = "subnet-id"
+      values = var.subnet_ids
+    }
+  }
+}

--- a/modules/opennext-lambda/iam.tf
+++ b/modules/opennext-lambda/iam.tf
@@ -42,3 +42,9 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role       = aws_iam_role.lambda_role.name
   policy_arn = aws_iam_policy.lambda_policy.arn
 }
+
+resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access" {
+  count      = var.vpc_id == null ? 0 : 1
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}

--- a/modules/opennext-lambda/lambda.tf
+++ b/modules/opennext-lambda/lambda.tf
@@ -49,7 +49,7 @@ resource "aws_lambda_function" "function" {
 
     content {
       security_group_ids = [aws_security_group.function_sg[0].id]
-      subnet_ids         = var.subnet_ids
+      subnet_ids         = data.aws_subnets.this[0].ids
     }
   }
 
@@ -85,7 +85,7 @@ resource "aws_security_group" "function_sg" {
   count = var.vpc_id == null ? 0 : 1
 
   name   = "${var.prefix}-sg"
-  vpc_id = var.vpc_id
+  vpc_id = data.aws_vopc.this[0].id
 
   egress {
     description = "Allow HTTPS egress from Lambda function"

--- a/modules/opennext-lambda/lambda.tf
+++ b/modules/opennext-lambda/lambda.tf
@@ -85,7 +85,7 @@ resource "aws_security_group" "function_sg" {
   count = var.vpc_id == null ? 0 : 1
 
   name   = "${var.prefix}-sg"
-  vpc_id = data.aws_vopc.this[0].id
+  vpc_id = data.aws_vpc.this[0].id
 
   egress {
     description = "Allow HTTPS egress from Lambda function"

--- a/modules/opennext-lambda/main.tf
+++ b/modules/opennext-lambda/main.tf
@@ -12,10 +12,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/modules/opennext-lambda/variables.tf
+++ b/modules/opennext-lambda/variables.tf
@@ -151,6 +151,12 @@ variable "subnet_ids" {
   default     = []
 }
 
+variable "subnet_map_public_ip" {
+  type        = bool
+  description = "The VPC to attach the lambda function to"
+  default     = false
+}
+
 variable "security_group_ingress_rules" {
   type = list(object({
     description      = string

--- a/modules/opennext-revalidation-queue/main.tf
+++ b/modules/opennext-revalidation-queue/main.tf
@@ -8,10 +8,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-  default_tags {
-    tags = var.default_tags
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -96,6 +96,7 @@ variable "server_options" {
     networking = optional(object({
       vpc_id     = optional(string)
       subnet_ids = optional(list(string))
+      subnet_map_public_ip = optional(bool)
       sg_ingress_rules = optional(list(object({
         description      = string
         from_port        = number
@@ -162,6 +163,7 @@ variable "image_optimization_options" {
     networking = optional(object({
       vpc_id     = optional(string)
       subnet_ids = optional(list(string))
+      subnet_map_public_ip = optional(bool)
       sg_ingress_rules = optional(list(object({
         description      = string
         from_port        = number
@@ -228,6 +230,7 @@ variable "revalidation_options" {
     networking = optional(object({
       vpc_id     = optional(string)
       subnet_ids = optional(list(string))
+      subnet_map_public_ip = optional(bool)
       sg_ingress_rules = optional(list(object({
         description      = string
         from_port        = number
@@ -302,6 +305,7 @@ variable "warmer_options" {
     networking = optional(object({
       vpc_id     = optional(string)
       subnet_ids = optional(list(string))
+      subnet_map_public_ip = optional(bool)
       sg_ingress_rules = optional(list(object({
         description      = string
         from_port        = number

--- a/variables.tf
+++ b/variables.tf
@@ -426,3 +426,11 @@ variable "cloudfront" {
     }))
   })
 }
+
+variable "cloudfront_log_options" {
+  description = "Variables passed to the cloudfront-logs module for the Next.js server"
+  type = object({
+    cloudwatch_log_group_kms_key_arn = optional(string)
+  })
+  default = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -393,6 +393,10 @@ variable "cloudfront" {
       name = optional(string)
       id   = optional(string)
     }))
+    existing_response_headers_policy = optional(object({
+      name = optional(string)
+      id   = optional(string)
+    }))
     custom_waf = optional(object({
       arn = string
     }))

--- a/variables.tf
+++ b/variables.tf
@@ -259,6 +259,14 @@ variable "revalidation_options" {
   default = {}
 }
 
+variable "revalidation_queue_options" {
+  description = "Variables passed to the opennext-revalidation-queue module for the ISR Revalidation Queue infrastructure"
+  type = object({
+    kms_key_arn = optional(string)
+  })
+  default = {}
+}
+
 variable "warmer_options" {
   description = "Variables passed to the opennext-lambda module for the Next.js Warmer function"
   type = object({
@@ -428,7 +436,7 @@ variable "cloudfront" {
 }
 
 variable "cloudfront_log_options" {
-  description = "Variables passed to the cloudfront-logs module for the Next.js server"
+  description = "Variables passed to the cloudfront-logs module for the CloudFront infrastructure"
   type = object({
     cloudwatch_log_group_kms_key_arn = optional(string)
   })

--- a/variables.tf
+++ b/variables.tf
@@ -369,6 +369,21 @@ variable "cloudfront" {
       override                   = bool
       preload                    = bool
     }))
+    content_security_policy = optional(object({
+      override = bool
+      policy   = string
+    }))
+    content_type_options = optional(object({
+      override = bool
+    }))
+    frame_options = optional(object({
+      override = bool
+      option   = string
+    }))
+    referrer_policy = optional(object({
+      override = bool
+      policy   = string
+    }))
     cache_policy = optional(object({
       default_ttl                   = optional(number)
       min_ttl                       = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -354,11 +354,11 @@ variable "cloudfront" {
       locations        = list(string)
     }))
     cors = optional(object({
-      allow_credentials = bool,
-      allow_headers     = list(string)
-      allow_methods     = list(string)
-      allow_origins     = list(string)
-      origin_override   = bool
+      allow_credentials = optional(bool)
+      allow_headers     = optional(list(string))
+      allow_methods     = optional(list(string))
+      allow_origins     = optional(list(string))
+      origin_override   = optional(bool)
     }))
     remove_headers_config = optional(object({
       items = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -389,6 +389,10 @@ variable "cloudfront" {
         items                 = optional(list(string))
       })
     }))
+    existing_cache_policy = optional(object({
+      name = optional(string)
+      id   = optional(string)
+    }))
     custom_waf = optional(object({
       arn = string
     }))

--- a/variables.tf
+++ b/variables.tf
@@ -389,11 +389,11 @@ variable "cloudfront" {
         items                 = optional(list(string))
       })
     }))
-    existing_cache_policy = optional(object({
+    custom_cache_policy = optional(object({
       name = optional(string)
       id   = optional(string)
     }))
-    existing_response_headers_policy = optional(object({
+    custom_response_headers_policy = optional(object({
       name = optional(string)
       id   = optional(string)
     }))


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding new headers to cloudfront as default:
- Content-Security-Policy
- Referrer-Policy
- X-Content-Type-Options
- X-Frame-Options

## Context

This is an improvement after pen testing tools found these best practice headers missing from requests to sites using this infrastructure

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
